### PR TITLE
Add YouTube transcript summarizer GitHub Pages site

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,18 @@
+# YouTube Video Summarizer
+
+This project is a self-contained GitHub Pages site that summarizes the transcript of a YouTube video using the OpenAI API. Provide a YouTube URL and your OpenAI API key to generate a short summary and bullet-point conclusions.
+
+## Usage
+1. Open `index.html` (or the deployed GitHub Pages site).
+2. Enter the YouTube video URL.
+3. Enter an OpenAI API key (the free tier works).
+4. Click **Summarize** to generate a summary.
+
+## Notes
+- The transcript is fetched from `youtubetranscript.com`. If a transcript is unavailable or the request fails, an error will be shown.
+- Summaries are generated via the `gpt-5-mini` chat completion endpoint.
+- Long videos might exceed token limits; short videos work best.
+- The summarization prompt lives in `prompt.md`; edit it to change the summary style.
+
+## Development
+No build step is required; the site is pure HTML/JS/CSS. Tests are not defined.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,92 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>YouTube Summarizer</title>
+    <style>
+        body { font-family: Arial, sans-serif; margin: 2rem; max-width: 800px; }
+        input, button { margin: 0.25rem 0; padding: 0.5rem; width: 100%; }
+        #summary { white-space: pre-wrap; margin-top: 1rem; }
+        .api { margin-top: 1rem; }
+    </style>
+</head>
+<body>
+    <h1>YouTube Video Summarizer</h1>
+    <p>Enter a YouTube URL and your OpenAI API key to summarize the video transcript.</p>
+    <input type="text" id="url" placeholder="YouTube URL">
+    <input type="text" id="apiKey" class="api" placeholder="OpenAI API Key">
+    <button id="summarize">Summarize</button>
+    <div id="status"></div>
+    <h2>Summary</h2>
+    <div id="summary"></div>
+
+    <script>
+    function parseVideoId(url) {
+        try {
+            const u = new URL(url);
+            if (u.hostname.includes('youtu.be')) {
+                return u.pathname.slice(1);
+            }
+            if (u.hostname.includes('youtube.com')) {
+                return u.searchParams.get('v');
+            }
+        } catch (e) {}
+        return null;
+    }
+
+    async function fetchTranscript(videoId) {
+        const res = await fetch(`https://youtubetranscript.com/?server_vid2=${videoId}`);
+        if (!res.ok) throw new Error('Transcript not available');
+        const data = await res.json();
+        return data.map(d => d.text).join(' ');
+    }
+
+    async function summarize(text, apiKey) {
+        const promptRes = await fetch('prompt.md');
+        if (!promptRes.ok) throw new Error('Prompt not found');
+        const prompt = await promptRes.text();
+        const res = await fetch('https://api.openai.com/v1/chat/completions', {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+                'Authorization': `Bearer ${apiKey}`
+            },
+            body: JSON.stringify({
+                model: 'gpt-5-mini',
+                messages: [
+                    { role: 'system', content: prompt },
+                    { role: 'user', content: text }
+                ]
+            })
+        });
+        if (!res.ok) {
+            const err = await res.text();
+            throw new Error(err);
+        }
+        const json = await res.json();
+        return json.choices[0].message.content.trim();
+    }
+
+    document.getElementById('summarize').addEventListener('click', async () => {
+        const url = document.getElementById('url').value;
+        const apiKey = document.getElementById('apiKey').value;
+        const status = document.getElementById('status');
+        const summaryEl = document.getElementById('summary');
+        summaryEl.textContent = '';
+        try {
+            status.textContent = 'Fetching transcript...';
+            const videoId = parseVideoId(url);
+            if (!videoId) throw new Error('Invalid URL');
+            const transcript = await fetchTranscript(videoId);
+            status.textContent = 'Summarizing...';
+            const summary = await summarize(transcript, apiKey);
+            summaryEl.textContent = summary;
+            status.textContent = 'Done.';
+        } catch (e) {
+            status.textContent = 'Error: ' + e.message;
+        }
+    });
+    </script>
+</body>
+</html>

--- a/prompt.md
+++ b/prompt.md
@@ -1,0 +1,1 @@
+You summarize YouTube transcripts into concise overviews followed by bullet-point conclusions.


### PR DESCRIPTION
## Summary
- add static `index.html` that fetches a YouTube transcript and uses OpenAI's gpt-5-mini model to generate a summary
- document usage and notes in `README.md`
- load summarization prompt from standalone `prompt.md` file

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a40c84284083229be280b31136cbeb