### PR TITLE
Store API key securely in browser

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,9 @@ This project is a self-contained GitHub Pages site that summarizes the transcrip
 ## Usage
 1. Open `index.html` (or the deployed GitHub Pages site).
 2. Enter the YouTube video URL.
-3. Enter an OpenAI API key (the free tier works).
+3. Enter an OpenAI API key (the free tier works) the first time you use the app. It will be stored encrypted in your browser for future visits.
 4. Click **Summarize** to generate a summary.
+5. To remove or change the key later, use the **Reset API Key** button.
 
 ## Notes
 - The transcript is fetched from `youtubetranscript.com`. If a transcript is unavailable or the request fails, an error will be shown.

--- a/index.html
+++ b/index.html
@@ -13,9 +13,10 @@
 </head>
 <body>
     <h1>YouTube Video Summarizer</h1>
-    <p>Enter a YouTube URL and your OpenAI API key to summarize the video transcript.</p>
+    <p>Enter a YouTube URL and (on first use) your OpenAI API key to summarize the video transcript. The key is stored securely in your browser and can be reset at any time.</p>
     <input type="text" id="url" placeholder="YouTube URL">
     <input type="text" id="apiKey" class="api" placeholder="OpenAI API Key">
+    <button id="resetKey" class="api" style="display:none;">Reset API Key</button>
     <button id="summarize">Summarize</button>
     <div id="status"></div>
     <h2>Summary</h2>
@@ -68,9 +69,96 @@
         return json.choices[0].message.content.trim();
     }
 
+    const DB_NAME = 'yousum-config';
+    const STORE_NAME = 'keys';
+
+    function openDB() {
+        return new Promise((resolve, reject) => {
+            const request = indexedDB.open(DB_NAME, 1);
+            request.onupgradeneeded = () => request.result.createObjectStore(STORE_NAME);
+            request.onsuccess = () => resolve(request.result);
+            request.onerror = () => reject(request.error);
+        });
+    }
+
+    async function getCryptoKey() {
+        const db = await openDB();
+        return new Promise((resolve, reject) => {
+            const tx = db.transaction(STORE_NAME, 'readonly');
+            const store = tx.objectStore(STORE_NAME);
+            const req = store.get('api');
+            req.onsuccess = async () => {
+                let key = req.result;
+                if (!key) {
+                    key = await crypto.subtle.generateKey(
+                        { name: 'AES-GCM', length: 256 },
+                        false,
+                        ['encrypt', 'decrypt']
+                    );
+                    const txw = db.transaction(STORE_NAME, 'readwrite');
+                    txw.objectStore(STORE_NAME).put(key, 'api');
+                    txw.oncomplete = () => resolve(key);
+                    txw.onerror = () => reject(txw.error);
+                } else {
+                    resolve(key);
+                }
+            };
+            req.onerror = () => reject(req.error);
+        });
+    }
+
+    async function saveApiKey(apiKey) {
+        const key = await getCryptoKey();
+        const iv = crypto.getRandomValues(new Uint8Array(12));
+        const encoded = new TextEncoder().encode(apiKey);
+        const ciphertext = await crypto.subtle.encrypt({ name: 'AES-GCM', iv }, key, encoded);
+        const payload = { iv: Array.from(iv), data: Array.from(new Uint8Array(ciphertext)) };
+        localStorage.setItem('apiKey', JSON.stringify(payload));
+    }
+
+    async function loadApiKey() {
+        const stored = localStorage.getItem('apiKey');
+        if (!stored) return '';
+        const key = await getCryptoKey();
+        const { iv, data } = JSON.parse(stored);
+        const ciphertext = new Uint8Array(data);
+        const buffer = await crypto.subtle.decrypt({ name: 'AES-GCM', iv: new Uint8Array(iv) }, key, ciphertext);
+        return new TextDecoder().decode(buffer);
+    }
+
+    document.addEventListener('DOMContentLoaded', async () => {
+        const apiInput = document.getElementById('apiKey');
+        const resetBtn = document.getElementById('resetKey');
+        const status = document.getElementById('status');
+        const saved = await loadApiKey();
+        if (saved) {
+            apiInput.value = saved;
+            apiInput.style.display = 'none';
+            resetBtn.style.display = 'block';
+            status.textContent = 'Using stored API key.';
+        }
+        resetBtn.addEventListener('click', async () => {
+            localStorage.removeItem('apiKey');
+            const db = await openDB();
+            const tx = db.transaction(STORE_NAME, 'readwrite');
+            tx.objectStore(STORE_NAME).delete('api');
+            tx.oncomplete = () => {
+                apiInput.value = '';
+                apiInput.style.display = 'block';
+                resetBtn.style.display = 'none';
+                status.textContent = 'API key cleared. Enter a new key.';
+            };
+        });
+    });
+
     document.getElementById('summarize').addEventListener('click', async () => {
         const url = document.getElementById('url').value;
-        const apiKey = document.getElementById('apiKey').value;
+        const apiInput = document.getElementById('apiKey');
+        const resetBtn = document.getElementById('resetKey');
+        const apiKey = apiInput.value;
+        await saveApiKey(apiKey);
+        apiInput.style.display = 'none';
+        resetBtn.style.display = 'block';
         const status = document.getElementById('status');
         const summaryEl = document.getElementById('summary');
         summaryEl.textContent = '';


### PR DESCRIPTION
## Summary
- Hide API key input after first save and show Reset API Key button
- Load and use stored API key automatically for future summaries
- Document reset process and one-time key entry in README

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a430d830448322867740e8342d2e2b