### PR TITLE
Use youtubetotranscript for transcript fetching

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This project is a self-contained GitHub Pages site that summarizes the transcrip
 5. To remove or change the key later, use the **Reset API Key** button.
 
 ## Notes
-- The transcript is fetched from `youtubetranscript.com`. If a transcript is unavailable or the request fails, an error will be shown.
+- The transcript is fetched from `youtubetotranscript.com`. If a transcript is unavailable or the request fails, an error will be shown.
 - Summaries are generated via the `gpt-5-mini` chat completion endpoint.
 - Long videos might exceed token limits; short videos work best.
 - The summarization prompt lives in `prompt.md`; edit it to change the summary style.

--- a/index.html
+++ b/index.html
@@ -37,10 +37,13 @@
     }
 
     async function fetchTranscript(videoId) {
-        const res = await fetch(`https://youtubetranscript.com/?server_vid2=${videoId}`);
+        const res = await fetch(`https://youtubetotranscript.com/transcript?v=${videoId}`);
         if (!res.ok) throw new Error('Transcript not available');
-        const data = await res.json();
-        return data.map(d => d.text).join(' ');
+        const html = await res.text();
+        const doc = new DOMParser().parseFromString(html, 'text/html');
+        const segments = Array.from(doc.querySelectorAll('span[data-start]'));
+        if (!segments.length) throw new Error('Transcript not found');
+        return segments.map(s => s.textContent.trim()).join(' ');
     }
 
     async function summarize(text, apiKey) {

--- a/tests/transcript-fetch.test.js
+++ b/tests/transcript-fetch.test.js
@@ -1,0 +1,17 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+
+const VIDEO_ID = 'i44jQvcDARo';
+const URL = `https://youtubetotranscript.com/transcript?v=${VIDEO_ID}`;
+
+function fetchTranscript() {
+  return spawnSync('curl', ['-s', '-A', 'Mozilla/5.0', URL], { encoding: 'utf8' });
+}
+
+test('fetches transcript HTML for the video without an API key', () => {
+  const result = fetchTranscript();
+  assert.equal(result.status, 0, `curl failed: ${result.stderr}`);
+  const hasSegment = /class="transcript-segment/.test(result.stdout);
+  assert.ok(hasSegment, 'No transcript segments returned');
+});


### PR DESCRIPTION
## Summary
- Fetch transcripts in the web app and tests from `youtubetotranscript.com`
- Parse returned HTML spans to assemble transcript text
- Document new transcript source

## Testing
- `node --test tests/transcript-fetch.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68a46236b24083228eab4bcc9f367a2a