### PR TITLE
Use passkeys to encrypt OpenAI API key client-side

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,10 @@ This project is a self-contained GitHub Pages site that summarizes the transcrip
 ## Usage
 1. Open `index.html` (or the deployed GitHub Pages site).
 2. Enter the YouTube video URL.
-3. Enter an OpenAI API key (the free tier works) the first time you use the app. It will be stored encrypted in your browser for future visits.
+3. Enter an OpenAI API key the first time you use the app. You'll be prompted to create a passkey (fingerprint/FaceID/PIN) which is required to encrypt and later decrypt the key.
 4. Click **Summarize** to generate a summary.
-5. To remove or change the key later, use the **Reset API Key** button.
+5. On later visits, click **Decrypt with passkey** to unlock the stored key before summarizing.
+6. To remove or change the key later, use the **Reset API Key** button.
 
 ## Notes
 - The transcript is fetched from `youtubetotranscript.com`. If a transcript is unavailable or the request fails, an error will be shown.
@@ -16,4 +17,4 @@ This project is a self-contained GitHub Pages site that summarizes the transcrip
 - The summarization prompt lives in `prompt.md`; edit it to change the summary style.
 
 ## Development
-No build step is required; the site is pure HTML/JS/CSS. Tests are not defined.
+No build step is required; the site is pure HTML/JS/CSS. Run `npm test` to execute the small test suite.

--- a/index.html
+++ b/index.html
@@ -3,19 +3,16 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'strict-dynamic'; object-src 'none'; base-uri 'none'; require-trusted-types-for 'script'">
     <title>YouTube Summarizer</title>
-    <style>
-        body { font-family: Arial, sans-serif; margin: 2rem; max-width: 800px; }
-        input, button { margin: 0.25rem 0; padding: 0.5rem; width: 100%; }
-        #summary { white-space: pre-wrap; margin-top: 1rem; }
-        .api { margin-top: 1rem; }
-    </style>
+    <link rel="stylesheet" href="styles.css">
 </head>
 <body>
     <h1>YouTube Video Summarizer</h1>
     <p>Enter a YouTube URL and (on first use) your OpenAI API key to summarize the video transcript. The key is stored securely in your browser and can be reset at any time.</p>
     <input type="text" id="url" placeholder="YouTube URL">
     <input type="text" id="apiKey" class="api" placeholder="OpenAI API Key">
+    <button id="decryptKey" class="api" style="display:none;">Decrypt with passkey</button>
     <button id="resetKey" class="api" style="display:none;">Reset API Key</button>
     <button id="summarize">Summarize</button>
     <div id="status"></div>

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,4 @@
+body { font-family: Arial, sans-serif; margin: 2rem; max-width: 800px; }
+input, button { margin: 0.25rem 0; padding: 0.5rem; width: 100%; }
+#summary { white-space: pre-wrap; margin-top: 1rem; }
+.api { margin-top: 1rem; }


### PR DESCRIPTION
## Summary
- Derive encryption keys from WebAuthn passkeys and store only ciphertext in IndexedDB
- Require biometric verification to decrypt stored API key and keep it out of the DOM
- Add strict Content Security Policy and Trusted Types while removing inline styles

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a485d574f0832297a0c15ea9c5555d