### PR TITLE
Add settings page with passkey-protected API key setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,12 +3,11 @@
 This project is a self-contained GitHub Pages site that summarizes the transcript of a YouTube video using the Together AI API. Provide a YouTube URL and your Together API key to generate a short summary and bullet-point conclusions.
 
 ## Usage
-1. Open `index.html` (or the deployed GitHub Pages site).
-2. Enter the YouTube video URL.
-3. Enter a Together API key the first time you use the app. You'll be prompted to create a passkey (fingerprint/FaceID/PIN) which is required to encrypt and later decrypt the key.
-4. Click **Summarize** to generate a summary.
-5. On later visits, click **Decrypt with passkey** to unlock the stored key before summarizing.
-6. To remove or change the key later, use the **Reset API Key** button.
+1. Open `settings.html` to configure the Together API key. Enter the key and save it; the browser will guide you through creating a passkey which is used to encrypt the key.
+2. (Optional) Use the **Decrypt with passkey** button on the settings page to authenticate and verify the stored key.
+3. Navigate to `index.html` (or the deployed GitHub Pages site).
+4. Enter the YouTube video URL and click **Summarize**. You will be prompted for your passkey to decrypt the stored API key before the summary is generated.
+5. To remove or change the key later, return to the settings page and use **Reset API Key**.
 
 ## Notes
 - The transcript is fetched from `youtubetotranscript.com`. If a transcript is unavailable or the request fails, an error will be shown.

--- a/index.html
+++ b/index.html
@@ -9,11 +9,8 @@
 </head>
 <body>
     <h1>YouTube Video Summarizer</h1>
-    <p>Enter a YouTube URL and (on first use) your Together API key to summarize the video transcript. The key is stored securely in your browser and can be reset at any time.</p>
+    <p>Enter a YouTube URL to summarize its transcript. Configure your Together API key on the <a href="settings.html">settings page</a>.</p>
     <input type="text" id="url" placeholder="YouTube URL">
-    <input type="text" id="apiKey" class="api" placeholder="Together API Key">
-    <button id="decryptKey" class="api" style="display:none;">Decrypt with passkey</button>
-    <button id="resetKey" class="api" style="display:none;">Reset API Key</button>
     <button id="summarize">Summarize</button>
     <div id="status"></div>
     <h2>Summary</h2>

--- a/keyManager.js
+++ b/keyManager.js
@@ -1,0 +1,143 @@
+const DB_NAME = 'yousum-config';
+const KEY_STORE = 'keys.store';
+const WEBAUTHN_STORE = 'webauthn';
+
+function openDB() {
+  return new Promise((resolve, reject) => {
+    const request = indexedDB.open(DB_NAME, 1);
+    request.onupgradeneeded = () => {
+      const db = request.result;
+      if (!db.objectStoreNames.contains(KEY_STORE)) db.createObjectStore(KEY_STORE);
+      if (!db.objectStoreNames.contains(WEBAUTHN_STORE)) db.createObjectStore(WEBAUTHN_STORE);
+    };
+    request.onsuccess = () => resolve(request.result);
+    request.onerror = () => reject(request.error);
+  });
+}
+
+async function storeCredId(id) {
+  const db = await openDB();
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(WEBAUTHN_STORE, 'readwrite');
+    tx.objectStore(WEBAUTHN_STORE).put(id, 'credId');
+    tx.oncomplete = () => resolve();
+    tx.onerror = () => reject(tx.error);
+  });
+}
+
+async function getCredId() {
+  const db = await openDB();
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(WEBAUTHN_STORE, 'readonly');
+    const req = tx.objectStore(WEBAUTHN_STORE).get('credId');
+    req.onsuccess = () => resolve(req.result);
+    req.onerror = () => reject(req.error);
+  });
+}
+
+async function storeKeyRecord(record) {
+  const db = await openDB();
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(KEY_STORE, 'readwrite');
+    tx.objectStore(KEY_STORE).put(record, 'apiKey');
+    tx.oncomplete = () => resolve();
+    tx.onerror = () => reject(tx.error);
+  });
+}
+
+export async function getKeyRecord() {
+  const db = await openDB();
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(KEY_STORE, 'readonly');
+    const req = tx.objectStore(KEY_STORE).get('apiKey');
+    req.onsuccess = () => resolve(req.result);
+    req.onerror = () => reject(req.error);
+  });
+}
+
+export async function clearStorage() {
+  const db = await openDB();
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction([KEY_STORE, WEBAUTHN_STORE], 'readwrite');
+    tx.objectStore(KEY_STORE).delete('apiKey');
+    tx.objectStore(WEBAUTHN_STORE).delete('credId');
+    tx.oncomplete = () => resolve();
+    tx.onerror = () => reject(tx.error);
+  });
+}
+
+async function registerPasskey() {
+  const publicKey = {
+    challenge: crypto.getRandomValues(new Uint8Array(32)),
+    rp: { name: 'YouSum' },
+    user: {
+      id: crypto.getRandomValues(new Uint8Array(32)),
+      name: 'local',
+      displayName: 'local'
+    },
+    pubKeyCredParams: [{ type: 'public-key', alg: -7 }],
+    authenticatorSelection: {
+      authenticatorAttachment: 'platform',
+      userVerification: 'required'
+    },
+    extensions: { prf: { enable: true } }
+  };
+  const cred = await navigator.credentials.create({ publicKey });
+  await storeCredId(cred.rawId);
+}
+
+async function deriveAesKey(salt) {
+  const credId = await getCredId();
+  if (!credId) throw new Error('No credential');
+  const assertion = await navigator.credentials.get({
+    publicKey: {
+      challenge: crypto.getRandomValues(new Uint8Array(32)),
+      allowCredentials: [{ id: credId, type: 'public-key' }],
+      userVerification: 'required',
+      extensions: { prf: { eval: { first: salt } } }
+    }
+  });
+  const exts = assertion.getClientExtensionResults();
+  const prfBytes = exts?.prf?.results?.first;
+  if (!prfBytes) throw new Error('PRF not supported');
+  const base = await crypto.subtle.importKey('raw', prfBytes, 'HKDF', false, ['deriveKey']);
+  return crypto.subtle.deriveKey(
+    { name: 'HKDF', hash: 'SHA-256', salt, info: new Uint8Array([]) },
+    base,
+    { name: 'AES-GCM', length: 256 },
+    false,
+    ['encrypt', 'decrypt']
+  );
+}
+
+export async function encryptAndStoreKey(apiKey) {
+  let credId = await getCredId();
+  if (!credId) {
+    await registerPasskey();
+  }
+  const salt = crypto.getRandomValues(new Uint8Array(32));
+  const aesKey = await deriveAesKey(salt);
+  const iv = crypto.getRandomValues(new Uint8Array(12));
+  const encoded = new TextEncoder().encode(apiKey);
+  const ciphertext = await crypto.subtle.encrypt({ name: 'AES-GCM', iv }, aesKey, encoded);
+  await storeKeyRecord({
+    ciphertext: Array.from(new Uint8Array(ciphertext)),
+    iv: Array.from(iv),
+    salt: Array.from(salt),
+    createdAt: Date.now()
+  });
+}
+
+export async function decryptStoredKey() {
+  const record = await getKeyRecord();
+  if (!record) throw new Error('No stored key');
+  const { ciphertext, iv, salt } = record;
+  const aesKey = await deriveAesKey(new Uint8Array(salt));
+  const buffer = await crypto.subtle.decrypt(
+    { name: 'AES-GCM', iv: new Uint8Array(iv) },
+    aesKey,
+    new Uint8Array(ciphertext)
+  );
+  return new TextDecoder().decode(buffer);
+}
+

--- a/main.js
+++ b/main.js
@@ -1,3 +1,5 @@
+import { getKeyRecord, decryptStoredKey } from './keyManager.js';
+
 export function parseVideoId(url) {
   try {
     const u = new URL(url);
@@ -8,7 +10,7 @@ export function parseVideoId(url) {
       return u.searchParams.get('v');
     }
   } catch {
-    // ignore
+    // ignore invalid URLs
   }
   return null;
 }
@@ -74,149 +76,6 @@ async function summarize(text, apiKey) {
   return json.choices[0].message.content.trim();
 }
 
-const DB_NAME = 'yousum-config';
-const KEY_STORE = 'keys.store';
-const WEBAUTHN_STORE = 'webauthn';
-
-function openDB() {
-  return new Promise((resolve, reject) => {
-    const request = indexedDB.open(DB_NAME, 1);
-    request.onupgradeneeded = () => {
-      const db = request.result;
-      if (!db.objectStoreNames.contains(KEY_STORE)) db.createObjectStore(KEY_STORE);
-      if (!db.objectStoreNames.contains(WEBAUTHN_STORE)) db.createObjectStore(WEBAUTHN_STORE);
-    };
-    request.onsuccess = () => resolve(request.result);
-    request.onerror = () => reject(request.error);
-  });
-}
-
-async function storeCredId(id) {
-  const db = await openDB();
-  return new Promise((resolve, reject) => {
-    const tx = db.transaction(WEBAUTHN_STORE, 'readwrite');
-    tx.objectStore(WEBAUTHN_STORE).put(id, 'credId');
-    tx.oncomplete = () => resolve();
-    tx.onerror = () => reject(tx.error);
-  });
-}
-
-async function getCredId() {
-  const db = await openDB();
-  return new Promise((resolve, reject) => {
-    const tx = db.transaction(WEBAUTHN_STORE, 'readonly');
-    const req = tx.objectStore(WEBAUTHN_STORE).get('credId');
-    req.onsuccess = () => resolve(req.result);
-    req.onerror = () => reject(req.error);
-  });
-}
-
-async function storeKeyRecord(record) {
-  const db = await openDB();
-  return new Promise((resolve, reject) => {
-    const tx = db.transaction(KEY_STORE, 'readwrite');
-    tx.objectStore(KEY_STORE).put(record, 'apiKey');
-    tx.oncomplete = () => resolve();
-    tx.onerror = () => reject(tx.error);
-  });
-}
-
-async function getKeyRecord() {
-  const db = await openDB();
-  return new Promise((resolve, reject) => {
-    const tx = db.transaction(KEY_STORE, 'readonly');
-    const req = tx.objectStore(KEY_STORE).get('apiKey');
-    req.onsuccess = () => resolve(req.result);
-    req.onerror = () => reject(req.error);
-  });
-}
-
-async function clearStorage() {
-  const db = await openDB();
-  return new Promise((resolve, reject) => {
-    const tx = db.transaction([KEY_STORE, WEBAUTHN_STORE], 'readwrite');
-    tx.objectStore(KEY_STORE).delete('apiKey');
-    tx.objectStore(WEBAUTHN_STORE).delete('credId');
-    tx.oncomplete = () => resolve();
-    tx.onerror = () => reject(tx.error);
-  });
-}
-
-async function registerPasskey() {
-  const publicKey = {
-    challenge: crypto.getRandomValues(new Uint8Array(32)),
-    rp: { name: 'YouSum' },
-    user: {
-      id: crypto.getRandomValues(new Uint8Array(32)),
-      name: 'local',
-      displayName: 'local'
-    },
-    pubKeyCredParams: [{ type: 'public-key', alg: -7 }],
-    authenticatorSelection: {
-      authenticatorAttachment: 'platform',
-      userVerification: 'required'
-    },
-    extensions: { prf: { enable: true } }
-  };
-  const cred = await navigator.credentials.create({ publicKey });
-  await storeCredId(cred.rawId);
-}
-
-async function deriveAesKey(salt) {
-  const credId = await getCredId();
-  if (!credId) throw new Error('No credential');
-  const assertion = await navigator.credentials.get({
-    publicKey: {
-      challenge: crypto.getRandomValues(new Uint8Array(32)),
-      allowCredentials: [{ id: credId, type: 'public-key' }],
-      userVerification: 'required',
-      extensions: { prf: { eval: { first: salt } } }
-    }
-  });
-  const exts = assertion.getClientExtensionResults();
-  const prfBytes = exts?.prf?.results?.first;
-  if (!prfBytes) throw new Error('PRF not supported');
-  const base = await crypto.subtle.importKey('raw', prfBytes, 'HKDF', false, ['deriveKey']);
-  return crypto.subtle.deriveKey(
-    { name: 'HKDF', hash: 'SHA-256', salt, info: new Uint8Array([]) },
-    base,
-    { name: 'AES-GCM', length: 256 },
-    false,
-    ['encrypt', 'decrypt']
-  );
-}
-
-async function encryptAndStoreKey(apiKey) {
-  let credId = await getCredId();
-  if (!credId) {
-    await registerPasskey();
-  }
-  const salt = crypto.getRandomValues(new Uint8Array(32));
-  const aesKey = await deriveAesKey(salt);
-  const iv = crypto.getRandomValues(new Uint8Array(12));
-  const encoded = new TextEncoder().encode(apiKey);
-  const ciphertext = await crypto.subtle.encrypt({ name: 'AES-GCM', iv }, aesKey, encoded);
-  await storeKeyRecord({
-    ciphertext: Array.from(new Uint8Array(ciphertext)),
-    iv: Array.from(iv),
-    salt: Array.from(salt),
-    createdAt: Date.now()
-  });
-}
-
-async function decryptStoredKey() {
-  const record = await getKeyRecord();
-  if (!record) throw new Error('No stored key');
-  const { ciphertext, iv, salt } = record;
-  const aesKey = await deriveAesKey(new Uint8Array(salt));
-  const buffer = await crypto.subtle.decrypt(
-    { name: 'AES-GCM', iv: new Uint8Array(iv) },
-    aesKey,
-    new Uint8Array(ciphertext)
-  );
-  return new TextDecoder().decode(buffer);
-}
-
 if (typeof window !== 'undefined' && window.trustedTypes && !window.trustedTypes.defaultPolicy) {
   window.trustedTypes.createPolicy('default', {
     createHTML: s => s,
@@ -227,53 +86,20 @@ if (typeof window !== 'undefined' && window.trustedTypes && !window.trustedTypes
 
 if (typeof document !== 'undefined') {
   document.addEventListener('DOMContentLoaded', async () => {
-    const apiInput = document.getElementById('apiKey');
-    const decryptBtn = document.getElementById('decryptKey');
-    const resetBtn = document.getElementById('resetKey');
     const status = document.getElementById('status');
-    let apiKey = '';
     const stored = await getKeyRecord();
-    if (stored) {
-      apiInput.style.display = 'none';
-      decryptBtn.style.display = 'block';
-      resetBtn.style.display = 'block';
-      status.textContent = 'Encrypted API key stored.';
+    if (!stored) {
+      status.textContent = 'No API key stored. Visit the settings page to configure one.';
     }
-
-    decryptBtn.addEventListener('click', async () => {
-      try {
-        status.textContent = 'Authenticating...';
-        apiKey = await decryptStoredKey();
-        status.textContent = 'API key decrypted.';
-        decryptBtn.style.display = 'none';
-      } catch (e) {
-        status.textContent = 'Error: ' + e.message;
-      }
-    });
-
-    resetBtn.addEventListener('click', async () => {
-      await clearStorage();
-      apiKey = '';
-      apiInput.value = '';
-      apiInput.style.display = 'block';
-      decryptBtn.style.display = 'none';
-      resetBtn.style.display = 'none';
-      status.textContent = 'API key cleared. Enter a new key.';
-    });
-
     document.getElementById('summarize').addEventListener('click', async () => {
       const url = document.getElementById('url').value;
       const summaryEl = document.getElementById('summary');
       summaryEl.textContent = '';
       try {
-        if (!apiKey) {
-          apiKey = apiInput.value.trim();
-          if (!apiKey) throw new Error('No API key');
-          await encryptAndStoreKey(apiKey);
-          apiInput.value = '';
-          apiInput.style.display = 'none';
-          resetBtn.style.display = 'block';
-        }
+        const record = await getKeyRecord();
+        if (!record) throw new Error('No stored API key. Use the settings page.');
+        status.textContent = 'Authenticating...';
+        const apiKey = await decryptStoredKey();
         status.textContent = 'Fetching transcript...';
         const videoId = parseVideoId(url);
         if (!videoId) throw new Error('Invalid URL');

--- a/settings.html
+++ b/settings.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'strict-dynamic'; object-src 'none'; base-uri 'none'; require-trusted-types-for 'script'">
+    <title>Settings</title>
+    <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+    <h1>Settings</h1>
+    <p>Use this page to configure the Together API key and set up passkey protection.</p>
+    <ol>
+        <li>Enter your Together API key below and press <strong>Save API Key</strong>.</li>
+        <li>If no passkey exists, the browser will ask you to create one. This passkey is used to encrypt your key.</li>
+        <li>After saving, use <strong>Decrypt with passkey</strong> to authenticate and confirm the key was stored correctly.</li>
+        <li>To start over at any time, click <strong>Reset API Key</strong> which deletes the stored key and passkey information.</li>
+    </ol>
+    <input type="text" id="apiKey" placeholder="Together API Key">
+    <button id="saveKey">Save API Key</button>
+    <button id="decryptKey" style="display:none;">Decrypt with passkey</button>
+    <button id="resetKey" style="display:none;">Reset API Key</button>
+    <div id="status"></div>
+    <p><a href="index.html">Back to summarizer</a></p>
+
+    <script type="module" src="settings.js"></script>
+</body>
+</html>

--- a/settings.js
+++ b/settings.js
@@ -1,0 +1,67 @@
+import { encryptAndStoreKey, decryptStoredKey, getKeyRecord, clearStorage } from './keyManager.js';
+
+if (typeof window !== 'undefined' && window.trustedTypes && !window.trustedTypes.defaultPolicy) {
+  window.trustedTypes.createPolicy('default', {
+    createHTML: s => s,
+    createScript: s => s,
+    createScriptURL: s => s
+  });
+}
+
+if (typeof document !== 'undefined') {
+  document.addEventListener('DOMContentLoaded', async () => {
+    const apiInput = document.getElementById('apiKey');
+    const saveBtn = document.getElementById('saveKey');
+    const decryptBtn = document.getElementById('decryptKey');
+    const resetBtn = document.getElementById('resetKey');
+    const status = document.getElementById('status');
+
+    const stored = await getKeyRecord();
+    if (stored) {
+      apiInput.style.display = 'none';
+      saveBtn.style.display = 'none';
+      decryptBtn.style.display = 'inline';
+      resetBtn.style.display = 'inline';
+      status.textContent = 'Encrypted API key stored.';
+    }
+
+    saveBtn.addEventListener('click', async () => {
+      const key = apiInput.value.trim();
+      if (!key) {
+        status.textContent = 'Please enter an API key.';
+        return;
+      }
+      try {
+        status.textContent = 'Saving key...';
+        await encryptAndStoreKey(key);
+        apiInput.value = '';
+        apiInput.style.display = 'none';
+        saveBtn.style.display = 'none';
+        decryptBtn.style.display = 'inline';
+        resetBtn.style.display = 'inline';
+        status.textContent = 'API key saved and encrypted.';
+      } catch (e) {
+        status.textContent = 'Error: ' + e.message;
+      }
+    });
+
+    decryptBtn.addEventListener('click', async () => {
+      try {
+        status.textContent = 'Authenticating...';
+        const key = await decryptStoredKey();
+        status.textContent = 'Decrypted API key: ' + key;
+      } catch (e) {
+        status.textContent = 'Error: ' + e.message;
+      }
+    });
+
+    resetBtn.addEventListener('click', async () => {
+      await clearStorage();
+      apiInput.style.display = 'inline';
+      saveBtn.style.display = 'inline';
+      decryptBtn.style.display = 'none';
+      resetBtn.style.display = 'none';
+      status.textContent = 'Stored key cleared.';
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- add dedicated settings page with step-by-step API key and passkey workflow
- move encryption logic to a reusable key manager module
- update main summarizer page to read key from new storage and link to settings

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a4c947c80c83228ab3d43482332f8b