### PR TITLE
Show errors in settings UI

### DIFF
--- a/settings.js
+++ b/settings.js
@@ -9,6 +9,7 @@ function showError(message) {
 
 window.addEventListener('error', (e) => showError(e.error?.message || e.message));
 window.addEventListener('unhandledrejection', (e) => {
+  e.preventDefault();
   const msg = e.reason?.message || e.reason;
   showError(msg);
 });


### PR DESCRIPTION
## Summary
- Add a reusable `showError` helper in `settings.js`
- Surface uncaught errors and promise rejections in the settings status area
- Use `showError` for Save API Key and Decrypt actions

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a4cc82ca488322896272094f8a7fc2