### PR TITLE
Add collapsible log view for step-by-step tracing

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,6 +13,10 @@
     <input type="text" id="url" placeholder="YouTube URL">
     <button id="summarize">Summarize</button>
     <div id="status"></div>
+    <details id="logBox">
+      <summary>Log</summary>
+      <pre id="log"></pre>
+    </details>
     <h2>Summary</h2>
     <div id="summary"></div>
 

--- a/main.js
+++ b/main.js
@@ -87,29 +87,34 @@ if (typeof window !== 'undefined' && window.trustedTypes && !window.trustedTypes
 if (typeof document !== 'undefined') {
   document.addEventListener('DOMContentLoaded', async () => {
     const status = document.getElementById('status');
+    const logEl = document.getElementById('log');
+    const log = msg => { if (logEl) logEl.textContent += msg + '\n'; };
+    const setStatus = msg => { status.textContent = msg; log(msg); };
+
     const stored = await getKeyRecord();
     if (!stored) {
-      status.textContent = 'No API key stored. Visit the settings page to configure one.';
+      setStatus('No API key stored. Visit the settings page to configure one.');
     }
     document.getElementById('summarize').addEventListener('click', async () => {
       const url = document.getElementById('url').value;
       const summaryEl = document.getElementById('summary');
       summaryEl.textContent = '';
+      if (logEl) logEl.textContent = '';
       try {
         const record = await getKeyRecord();
         if (!record) throw new Error('No stored API key. Use the settings page.');
-        status.textContent = 'Authenticating...';
+        setStatus('Authenticating...');
         const apiKey = await decryptStoredKey();
-        status.textContent = 'Fetching transcript...';
+        setStatus('Fetching transcript...');
         const videoId = parseVideoId(url);
         if (!videoId) throw new Error('Invalid URL');
         const { transcript, title } = await fetchTranscript(videoId);
-        status.textContent = `Summarizing "${title}"...`;
+        setStatus(`Summarizing "${title}"...`);
         const summary = await summarize(transcript, apiKey);
         summaryEl.textContent = summary;
-        status.textContent = 'Done.';
+        setStatus('Done.');
       } catch (e) {
-        status.textContent = 'Error: ' + e.message;
+        setStatus('Error: ' + e.message);
       }
     });
   });

--- a/settings.html
+++ b/settings.html
@@ -21,6 +21,10 @@
     <button id="decryptKey" style="display:none;">Decrypt with passkey</button>
     <button id="resetKey" style="display:none;">Reset API Key</button>
     <div id="status"></div>
+    <details id="logBox">
+      <summary>Log</summary>
+      <pre id="log"></pre>
+    </details>
     <p><a href="index.html">Back to summarizer</a></p>
 
     <script type="module" src="settings.js"></script>

--- a/settings.js
+++ b/settings.js
@@ -2,9 +2,9 @@ import { encryptAndStoreKey, decryptStoredKey, getKeyRecord, clearStorage } from
 
 function showError(message) {
   const status = document.getElementById('status');
-  if (status) {
-    status.textContent = 'Error: ' + message;
-  }
+  const logEl = document.getElementById('log');
+  if (status) status.textContent = 'Error: ' + message;
+  if (logEl) logEl.textContent += 'Error: ' + message + '\n';
 }
 
 window.addEventListener('error', (e) => showError(e.error?.message || e.message));
@@ -29,6 +29,11 @@ if (typeof document !== 'undefined') {
     const decryptBtn = document.getElementById('decryptKey');
     const resetBtn = document.getElementById('resetKey');
     const status = document.getElementById('status');
+    const logEl = document.getElementById('log');
+    const setStatus = msg => {
+      status.textContent = msg;
+      if (logEl) logEl.textContent += msg + '\n';
+    };
 
     const stored = await getKeyRecord();
     if (stored) {
@@ -36,24 +41,24 @@ if (typeof document !== 'undefined') {
       saveBtn.style.display = 'none';
       decryptBtn.style.display = 'inline';
       resetBtn.style.display = 'inline';
-      status.textContent = 'Encrypted API key stored.';
+      setStatus('Encrypted API key stored.');
     }
 
     saveBtn.addEventListener('click', async () => {
       const key = apiInput.value.trim();
       if (!key) {
-        status.textContent = 'Please enter an API key.';
+        setStatus('Please enter an API key.');
         return;
       }
       try {
-        status.textContent = 'Saving key...';
+        setStatus('Saving key...');
         await encryptAndStoreKey(key);
         apiInput.value = '';
         apiInput.style.display = 'none';
         saveBtn.style.display = 'none';
         decryptBtn.style.display = 'inline';
         resetBtn.style.display = 'inline';
-        status.textContent = 'API key saved and encrypted.';
+        setStatus('API key saved and encrypted.');
       } catch (e) {
         showError(e.message);
       }
@@ -61,9 +66,9 @@ if (typeof document !== 'undefined') {
 
     decryptBtn.addEventListener('click', async () => {
       try {
-        status.textContent = 'Authenticating...';
+        setStatus('Authenticating...');
         const key = await decryptStoredKey();
-        status.textContent = 'API key successfully decrypted.';
+        setStatus('API key successfully decrypted.');
       } catch (e) {
         showError(e.message);
       }
@@ -75,7 +80,7 @@ if (typeof document !== 'undefined') {
       saveBtn.style.display = 'inline';
       decryptBtn.style.display = 'none';
       resetBtn.style.display = 'none';
-      status.textContent = 'Stored key cleared.';
+      setStatus('Stored key cleared.');
     });
   });
 }


### PR DESCRIPTION
## Summary
- add collapsible "Log" sections to summarizer and settings pages
- log each status update so users can trace authentication, transcript fetch and other actions

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a4d085300c8322ad1f62ea902047d5