### PR TITLE
Add error logging and expand CSP for API calls

### DIFF
--- a/errors.js
+++ b/errors.js
@@ -1,0 +1,15 @@
+// Surface errors on the main page so users see why actions may fail.
+// (Kept as an external file so CSP can remain `script-src 'self'` without inline allowances.)
+(() => {
+  function append(msg) {
+    const el = document.getElementById('log');
+    if (el) el.textContent += String(msg) + '\n';
+  }
+  window.addEventListener('error', (e) => {
+    append('Error: ' + (e.error?.message || e.message));
+  });
+  window.addEventListener('unhandledrejection', (e) => {
+    e.preventDefault();
+    append('Error: ' + (e.reason?.message || e.reason));
+  });
+})();

--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'strict-dynamic'; object-src 'none'; base-uri 'none'; require-trusted-types-for 'script'">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; connect-src 'self' https://api.together.xyz https://youtubetotranscript.com; object-src 'none'; base-uri 'none'; require-trusted-types-for 'script'">
     <title>YouTube Summarizer</title>
     <link rel="stylesheet" href="styles.css">
 </head>
@@ -20,6 +20,7 @@
     <h2>Summary</h2>
     <div id="summary"></div>
 
+    <script src="errors.js"></script>
     <script type="module" src="main.js"></script>
 </body>
 </html>

--- a/settings.html
+++ b/settings.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'strict-dynamic'; object-src 'none'; base-uri 'none'; require-trusted-types-for 'script'">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; connect-src 'self' https://api.together.xyz https://youtubetotranscript.com; object-src 'none'; base-uri 'none'; require-trusted-types-for 'script'">
     <title>Settings</title>
     <link rel="stylesheet" href="styles.css">
 </head>


### PR DESCRIPTION
## Summary
- Broaden CSP connect-src to allow Together API and transcript service
- Add external errors.js to surface unhandled runtime errors on log

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a5875b0d348322852ed499e45dca6a