### PR TITLE
Use PIN-based Web Crypto storage for API key

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,10 +3,10 @@
 This project is a self-contained GitHub Pages site that summarizes the transcript of a YouTube video using the Together AI API. Provide a YouTube URL and your Together API key to generate a short summary and bullet-point conclusions.
 
 ## Usage
-1. Open `settings.html` to configure the Together API key. Enter the key and save it; the browser will guide you through creating a passkey which is used to securely store the key.
-2. (Optional) Use the **Decrypt with passkey** button on the settings page to authenticate and verify the stored key.
+1. Open `settings.html` to configure the Together API key. Enter the key and choose a PIN, then save it. If supported, the browser may also ask you to create a passkey for biometric authentication.
+2. (Optional) Use the **Decrypt stored key** button on the settings page to authenticate and verify the stored key by entering your PIN.
 3. Navigate to `index.html` (or the deployed GitHub Pages site).
-4. Enter the YouTube video URL and click **Summarize**. You will be prompted for your passkey to decrypt the stored API key before the summary is generated.
+4. Enter the YouTube video URL and click **Summarize**. You will be prompted for your PIN to decrypt the stored API key before the summary is generated.
 5. To remove or change the key later, return to the settings page and use **Reset API Key**.
 
 ## Notes
@@ -14,7 +14,7 @@ This project is a self-contained GitHub Pages site that summarizes the transcrip
 - Summaries are generated via the `meta-llama/Llama-3.3-70B-Instruct-Turbo-Free` chat completion endpoint provided by Together AI.
 - Long videos might exceed token limits; short videos work best.
 - The summarization prompt lives in `prompt.md`; edit it to change the summary style.
-- Secure key storage uses the WebAuthn largeBlob extension, available in modern browsers, to protect the API key with your passkey. If your browser lacks this extension, saving the API key will fail.
+- Secure key storage uses the Web Crypto API to encrypt the API key with a PIN you choose. Passkeys may be used for additional authentication, but are not required and no experimental browser extensions are needed.
 
 ## Development
 No build step is required; the site is pure HTML/JS/CSS. Run `npm test` to execute the small test suite.

--- a/index.html
+++ b/index.html
@@ -9,7 +9,7 @@
 </head>
 <body>
     <h1>YouTube Video Summarizer</h1>
-    <p>Enter a YouTube URL to summarize its transcript. Configure your Together API key on the <a href="settings.html">settings page</a>.</p>
+    <p>Enter a YouTube URL to summarize its transcript. Configure your Together API key and PIN on the <a href="settings.html">settings page</a>.</p>
     <input type="text" id="url" placeholder="YouTube URL">
     <button id="summarize">Summarize</button>
     <div id="status"></div>

--- a/main.js
+++ b/main.js
@@ -103,8 +103,10 @@ if (typeof document !== 'undefined') {
       try {
         const record = await getKeyRecord();
         if (!record) throw new Error('No stored API key. Use the settings page.');
+        const pin = prompt('Enter PIN');
+        if (!pin) throw new Error('PIN required');
         setStatus('Authenticating...');
-        const apiKey = await decryptStoredKey();
+        const apiKey = await decryptStoredKey(pin);
         setStatus('Fetching transcript...');
         const videoId = parseVideoId(url);
         if (!videoId) throw new Error('Invalid URL');

--- a/settings.html
+++ b/settings.html
@@ -9,16 +9,17 @@
 </head>
 <body>
     <h1>Settings</h1>
-    <p>Use this page to configure the Together API key and set up passkey protection.</p>
+    <p>Use this page to configure the Together API key and set up PIN protection. If your browser supports passkeys, a fingerprint or device authentication may also be requested.</p>
     <ol>
-        <li>Enter your Together API key below and press <strong>Save API Key</strong>.</li>
-        <li>If no passkey exists, the browser will ask you to create one. This passkey is used to encrypt your key.</li>
-        <li>After saving, use <strong>Decrypt with passkey</strong> to authenticate and confirm the key was stored correctly.</li>
+        <li>Enter your Together API key and choose a PIN, then press <strong>Save API Key</strong>.</li>
+        <li>If your browser supports passkeys, it may prompt you to create one for biometric authentication.</li>
+        <li>After saving, use <strong>Decrypt stored key</strong> to authenticate and confirm the key was stored correctly.</li>
         <li>To start over at any time, click <strong>Reset API Key</strong> which deletes the stored key and passkey information.</li>
     </ol>
     <input type="text" id="apiKey" placeholder="Together API Key">
+    <input type="password" id="pin" placeholder="PIN">
     <button id="saveKey">Save API Key</button>
-    <button id="decryptKey" style="display:none;">Decrypt with passkey</button>
+    <button id="decryptKey" style="display:none;">Decrypt stored key</button>
     <button id="resetKey" style="display:none;">Reset API Key</button>
     <div id="status"></div>
     <details id="logBox">

--- a/settings.js
+++ b/settings.js
@@ -28,6 +28,7 @@ if (typeof document !== 'undefined') {
     const saveBtn = document.getElementById('saveKey');
     const decryptBtn = document.getElementById('decryptKey');
     const resetBtn = document.getElementById('resetKey');
+    const pinInput = document.getElementById('pin');
     const status = document.getElementById('status');
     const logEl = document.getElementById('log');
     const setStatus = msg => {
@@ -38,6 +39,7 @@ if (typeof document !== 'undefined') {
     const stored = await getKeyRecord();
     if (stored) {
       apiInput.style.display = 'none';
+      pinInput.style.display = 'none';
       saveBtn.style.display = 'none';
       decryptBtn.style.display = 'inline';
       resetBtn.style.display = 'inline';
@@ -46,15 +48,18 @@ if (typeof document !== 'undefined') {
 
     saveBtn.addEventListener('click', async () => {
       const key = apiInput.value.trim();
-      if (!key) {
-        setStatus('Please enter an API key.');
+      const pin = pinInput.value;
+      if (!key || !pin) {
+        setStatus('Please enter an API key and PIN.');
         return;
       }
       try {
         setStatus('Saving key...');
-        await encryptAndStoreKey(key);
+        await encryptAndStoreKey(key, pin);
         apiInput.value = '';
+        pinInput.value = '';
         apiInput.style.display = 'none';
+        pinInput.style.display = 'none';
         saveBtn.style.display = 'none';
         decryptBtn.style.display = 'inline';
         resetBtn.style.display = 'inline';
@@ -66,8 +71,13 @@ if (typeof document !== 'undefined') {
 
     decryptBtn.addEventListener('click', async () => {
       try {
+        const pin = prompt('Enter PIN');
+        if (!pin) {
+          setStatus('PIN required.');
+          return;
+        }
         setStatus('Authenticating...');
-        const key = await decryptStoredKey();
+        const key = await decryptStoredKey(pin);
         setStatus('API key successfully decrypted.');
       } catch (e) {
         showError(e.message);
@@ -77,6 +87,7 @@ if (typeof document !== 'undefined') {
     resetBtn.addEventListener('click', async () => {
       await clearStorage();
       apiInput.style.display = 'inline';
+      pinInput.style.display = 'inline';
       saveBtn.style.display = 'inline';
       decryptBtn.style.display = 'none';
       resetBtn.style.display = 'none';


### PR DESCRIPTION
## Summary
- Replace experimental WebAuthn largeBlob storage with Web Crypto encryption using a user-defined PIN
- Optionally authenticate with passkeys for fingerprint/device security, no browser extensions required
- Update settings and main flows to prompt for PIN and refresh documentation accordingly

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a5d0991840832299f3d570f002239c