### PR TITLE
Adapt token usage to transcript length

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This project is a self-contained GitHub Pages site that summarizes the transcrip
 ## Notes
 - The transcript is fetched from `youtubetotranscript.com`. If a transcript is unavailable or the request fails, an error will be shown.
 - Summaries are generated via the `meta-llama/Llama-3.3-70B-Instruct-Turbo-Free` chat completion endpoint provided by Together AI.
-- Long videos might exceed token limits; short videos work best.
+- Long videos may exceed token limits; the app truncates transcripts and adjusts the output length to stay within Together AI's limits.
 - The summarization prompt lives in `prompt.md`; edit it to change the summary style.
 - Secure key storage uses the Web Crypto API to encrypt the API key with a PIN you choose. Passkeys may be used for additional authentication, but are not required and no experimental browser extensions are needed.
 

--- a/main.js
+++ b/main.js
@@ -50,10 +50,27 @@ export async function fetchTranscript(videoId) {
   return { transcript, title };
 }
 
+function estimateTokens(str) {
+  return Math.ceil(str.length / 4);
+}
+
 async function summarize(text, apiKey) {
   const promptRes = await fetch('prompt.md');
   if (!promptRes.ok) throw new Error('Prompt not found');
   const prompt = await promptRes.text();
+
+  const LIMIT = 8192;
+  const MAX_OUTPUT = 2048;
+  const promptTokens = estimateTokens(prompt);
+  let textTokens = estimateTokens(text);
+  if (promptTokens + textTokens >= LIMIT) {
+    const allowed = LIMIT - promptTokens - 1;
+    const ratio = allowed / textTokens;
+    text = text.slice(0, Math.floor(text.length * ratio));
+    textTokens = estimateTokens(text);
+  }
+  const maxTokens = Math.max(1, Math.min(MAX_OUTPUT, LIMIT - promptTokens - textTokens));
+
   const res = await fetch('https://api.together.xyz/v1/chat/completions', {
     method: 'POST',
     headers: {
@@ -62,6 +79,7 @@ async function summarize(text, apiKey) {
     },
     body: JSON.stringify({
       model: 'meta-llama/Llama-3.3-70B-Instruct-Turbo-Free',
+      max_tokens: maxTokens,
       messages: [
         { role: 'system', content: prompt },
         { role: 'user', content: text }


### PR DESCRIPTION
## Summary
- Estimate transcript tokens and truncate when needed to respect Together's 8k limit
- Dynamically set `max_tokens` for chat completions so output fits within remaining budget
- Document automatic truncation and token adjustment in README

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a63e4fd7188322a5a6c746dc877836