### PR TITLE
feat: default to biometric auth when available

### DIFF
--- a/main.js
+++ b/main.js
@@ -103,10 +103,20 @@ if (typeof document !== 'undefined') {
       try {
         const record = await getKeyRecord();
         if (!record) throw new Error('No stored API key. Use the settings page.');
-        const pin = prompt('Enter PIN');
-        if (!pin) throw new Error('PIN required');
-        setStatus('Authenticating...');
-        const apiKey = await decryptStoredKey(pin);
+        let apiKey;
+        try {
+          setStatus('Authenticating...');
+          apiKey = await decryptStoredKey();
+        } catch (e) {
+          if (e.message === 'PIN required') {
+            const pin = prompt('Enter PIN');
+            if (!pin) throw new Error('PIN required');
+            setStatus('Authenticating...');
+            apiKey = await decryptStoredKey(pin);
+          } else {
+            throw e;
+          }
+        }
         setStatus('Fetching transcript...');
         const videoId = parseVideoId(url);
         if (!videoId) throw new Error('Invalid URL');

--- a/settings.js
+++ b/settings.js
@@ -71,13 +71,23 @@ if (typeof document !== 'undefined') {
 
     decryptBtn.addEventListener('click', async () => {
       try {
-        const pin = prompt('Enter PIN');
-        if (!pin) {
-          setStatus('PIN required.');
-          return;
-        }
         setStatus('Authenticating...');
-        const key = await decryptStoredKey(pin);
+        let key;
+        try {
+          key = await decryptStoredKey();
+        } catch (e) {
+          if (e.message === 'PIN required') {
+            const pin = prompt('Enter PIN');
+            if (!pin) {
+              setStatus('PIN required.');
+              return;
+            }
+            setStatus('Authenticating...');
+            key = await decryptStoredKey(pin);
+          } else {
+            throw e;
+          }
+        }
         setStatus('API key successfully decrypted.');
       } catch (e) {
         showError(e.message);


### PR DESCRIPTION
## Summary
- Try biometric authentication first when storing and retrieving the API key
- Fall back to PIN only if biometrics are unavailable or fail
- Update UI flows to attempt biometrics before prompting for a PIN

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a63f0ccc3c8322a6147ce63ac797f2