### PR TITLE
Remove biometrics and add API retries

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 This project is a self-contained GitHub Pages site that summarizes the transcript of a YouTube video using the Together AI API. Provide a YouTube URL and your Together API key to generate a short summary and bullet-point conclusions.
 
 ## Usage
-1. Open `settings.html` to configure the Together API key. Enter the key and choose a PIN, then save it. If supported, the browser may also ask you to create a passkey for biometric authentication.
+1. Open `settings.html` to configure the Together API key. Enter the key and choose a PIN, then save it.
 2. (Optional) Use the **Decrypt stored key** button on the settings page to authenticate and verify the stored key by entering your PIN.
 3. Navigate to `index.html` (or the deployed GitHub Pages site).
 4. Enter the YouTube video URL and click **Summarize**. You will be prompted for your PIN to decrypt the stored API key before the summary is generated.
@@ -14,7 +14,7 @@ This project is a self-contained GitHub Pages site that summarizes the transcrip
 - Summaries are generated via the `meta-llama/Llama-3.3-70B-Instruct-Turbo-Free` chat completion endpoint provided by Together AI.
 - Long videos may exceed token limits; the app truncates transcripts and adjusts the output length to stay within Together AI's limits.
 - The summarization prompt lives in `prompt.md`; edit it to change the summary style.
-- Secure key storage uses the Web Crypto API to encrypt the API key with a PIN you choose. Passkeys may be used for additional authentication, but are not required and no experimental browser extensions are needed.
+- Secure key storage uses the Web Crypto API to encrypt the API key with a PIN you choose.
 
 ## Development
 No build step is required; the site is pure HTML/JS/CSS. Run `npm test` to execute the small test suite.

--- a/settings.html
+++ b/settings.html
@@ -9,12 +9,11 @@
 </head>
 <body>
     <h1>Settings</h1>
-    <p>Use this page to configure the Together API key and set up PIN protection. If your browser supports passkeys, a fingerprint or device authentication may also be requested.</p>
+    <p>Use this page to configure the Together API key and set up PIN protection.</p>
     <ol>
         <li>Enter your Together API key and choose a PIN, then press <strong>Save API Key</strong>.</li>
-        <li>If your browser supports passkeys, it may prompt you to create one for biometric authentication.</li>
         <li>After saving, use <strong>Decrypt stored key</strong> to authenticate and confirm the key was stored correctly.</li>
-        <li>To start over at any time, click <strong>Reset API Key</strong> which deletes the stored key and passkey information.</li>
+        <li>To start over at any time, click <strong>Reset API Key</strong> which deletes the stored key.</li>
     </ol>
     <input type="text" id="apiKey" placeholder="Together API Key">
     <input type="password" id="pin" placeholder="PIN">

--- a/settings.js
+++ b/settings.js
@@ -70,24 +70,14 @@ if (typeof document !== 'undefined') {
     });
 
     decryptBtn.addEventListener('click', async () => {
+      const pin = prompt('Enter PIN');
+      if (!pin) {
+        setStatus('PIN required.');
+        return;
+      }
       try {
         setStatus('Authenticating...');
-        let key;
-        try {
-          key = await decryptStoredKey();
-        } catch (e) {
-          if (e.message === 'PIN required') {
-            const pin = prompt('Enter PIN');
-            if (!pin) {
-              setStatus('PIN required.');
-              return;
-            }
-            setStatus('Authenticating...');
-            key = await decryptStoredKey(pin);
-          } else {
-            throw e;
-          }
-        }
+        await decryptStoredKey(pin);
         setStatus('API key successfully decrypted.');
       } catch (e) {
         showError(e.message);


### PR DESCRIPTION
## Summary
- drop WebAuthn biometrics so API key storage relies solely on PIN encryption
- add retry helper for Together API calls to handle temporary service outages
- update settings and docs to reflect PIN-only authentication

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a645eeedbc832282df975c02f20f87