### PR TITLE
Switch to Groq gpt-oss model with fixed output tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # YouTube Video Summarizer
 
-This project is a self-contained GitHub Pages site that summarizes the transcript of a YouTube video using the Together AI API. Provide a YouTube URL and your Together API key to generate a short summary and bullet-point conclusions.
+This project is a self-contained GitHub Pages site that summarizes the transcript of a YouTube video using the Groq API. Provide a YouTube URL and your Groq API key to generate a short summary and bullet-point conclusions.
 
 ## Usage
-1. Open `settings.html` to configure the Together API key. Enter the key and choose a PIN, then save it.
+1. Open `settings.html` to configure the Groq API key. Enter the key and choose a PIN, then save it.
 2. (Optional) Use the **Decrypt stored key** button on the settings page to authenticate and verify the stored key by entering your PIN.
 3. Navigate to `index.html` (or the deployed GitHub Pages site).
 4. Enter the YouTube video URL and click **Summarize**. You will be prompted for your PIN to decrypt the stored API key before the summary is generated.
@@ -11,8 +11,8 @@ This project is a self-contained GitHub Pages site that summarizes the transcrip
 
 ## Notes
 - The transcript is fetched from `youtubetotranscript.com`. If a transcript is unavailable or the request fails, an error will be shown.
-- Summaries are generated via the `meta-llama/Llama-3.3-70B-Instruct-Turbo-Free` chat completion endpoint provided by Together AI.
-- Long videos may exceed token limits; the app truncates transcripts and adjusts the output length to stay within Together AI's limits.
+- Summaries are generated via the `openai/gpt-oss-120b` chat completion endpoint provided by Groq.
+- The `openai/gpt-oss-120b` model offers a large context window, so the app sends the full transcript without calculating token limits.
 - The summarization prompt lives in `prompt.md`; edit it to change the summary style.
 - Secure key storage uses the Web Crypto API to encrypt the API key with a PIN you choose.
 

--- a/index.html
+++ b/index.html
@@ -3,13 +3,13 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; connect-src 'self' https://api.together.xyz https://youtubetotranscript.com; object-src 'none'; base-uri 'none'; require-trusted-types-for 'script'">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; connect-src 'self' https://api.groq.com https://youtubetotranscript.com; object-src 'none'; base-uri 'none'; require-trusted-types-for 'script'">
     <title>YouTube Summarizer</title>
     <link rel="stylesheet" href="styles.css">
 </head>
 <body>
     <h1>YouTube Video Summarizer</h1>
-    <p>Enter a YouTube URL to summarize its transcript. Configure your Together API key and PIN on the <a href="settings.html">settings page</a>.</p>
+    <p>Enter a YouTube URL to summarize its transcript. Configure your Groq API key and PIN on the <a href="settings.html">settings page</a>.</p>
     <input type="text" id="url" placeholder="YouTube URL">
     <button id="summarize">Summarize</button>
     <div id="status"></div>

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "yousum",
   "version": "1.0.0",
-  "description": "This project is a self-contained GitHub Pages site that summarizes the transcript of a YouTube video using the Together AI API. Provide a YouTube URL and your Together API key to generate a short summary and bullet-point conclusions.",
+  "description": "This project is a self-contained GitHub Pages site that summarizes the transcript of a YouTube video using the Groq API. Provide a YouTube URL and your Groq API key to generate a short summary and bullet-point conclusions.",
   "main": "index.js",
   "directories": {
     "test": "tests"

--- a/settings.html
+++ b/settings.html
@@ -3,19 +3,19 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; connect-src 'self' https://api.together.xyz https://youtubetotranscript.com; object-src 'none'; base-uri 'none'; require-trusted-types-for 'script'">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; connect-src 'self' https://api.groq.com https://youtubetotranscript.com; object-src 'none'; base-uri 'none'; require-trusted-types-for 'script'">
     <title>Settings</title>
     <link rel="stylesheet" href="styles.css">
 </head>
 <body>
     <h1>Settings</h1>
-    <p>Use this page to configure the Together API key and set up PIN protection.</p>
+    <p>Use this page to configure the Groq API key and set up PIN protection.</p>
     <ol>
-        <li>Enter your Together API key and choose a PIN, then press <strong>Save API Key</strong>.</li>
+        <li>Enter your Groq API key and choose a PIN, then press <strong>Save API Key</strong>.</li>
         <li>After saving, use <strong>Decrypt stored key</strong> to authenticate and confirm the key was stored correctly.</li>
         <li>To start over at any time, click <strong>Reset API Key</strong> which deletes the stored key.</li>
     </ol>
-    <input type="text" id="apiKey" placeholder="Together API Key">
+    <input type="text" id="apiKey" placeholder="Groq API Key">
     <input type="password" id="pin" placeholder="PIN">
     <button id="saveKey">Save API Key</button>
     <button id="decryptKey" style="display:none;">Decrypt stored key</button>


### PR DESCRIPTION
## Summary
- Replace Together API usage with Groq's `openai/gpt-oss-120b` model and hardcode `max_completion_tokens`.
- Remove token length calculations and update HTML CSP/connect references to `api.groq.com`.
- Refresh documentation and settings to reference Groq API keys.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a6d91d77ec8322a4d7b2d6fc3001f9