### PR TITLE
feat: add dark theme and markdown rendering

### DIFF
--- a/main.js
+++ b/main.js
@@ -15,6 +15,40 @@ export function parseVideoId(url) {
   return null;
 }
 
+function renderMarkdown(md) {
+  const lines = md.split(/\r?\n/);
+  let html = '';
+  let inList = false;
+  for (let raw of lines) {
+    let line = raw
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/\*\*(.+?)\*\*/g, '<strong>$1</strong>')
+      .replace(/\*(.+?)\*/g, '<em>$1</em>');
+    if (/^###\s+/.test(line)) {
+      if (inList) { html += '</ul>'; inList = false; }
+      html += '<h3>' + line.replace(/^###\s+/, '') + '</h3>';
+    } else if (/^##\s+/.test(line)) {
+      if (inList) { html += '</ul>'; inList = false; }
+      html += '<h2>' + line.replace(/^##\s+/, '') + '</h2>';
+    } else if (/^#\s+/.test(line)) {
+      if (inList) { html += '</ul>'; inList = false; }
+      html += '<h1>' + line.replace(/^#\s+/, '') + '</h1>';
+    } else if (/^[-*]\s+/.test(line)) {
+      if (!inList) { html += '<ul>'; inList = true; }
+      html += '<li>' + line.replace(/^[-*]\s+/, '') + '</li>';
+    } else if (line.trim() === '') {
+      if (inList) { html += '</ul>'; inList = false; }
+    } else {
+      if (inList) { html += '</ul>'; inList = false; }
+      html += '<p>' + line + '</p>';
+    }
+  }
+  if (inList) html += '</ul>';
+  return html;
+}
+
 async function parseHtml(html) {
   if (typeof DOMParser !== 'undefined') {
     return new DOMParser().parseFromString(html, 'text/html');
@@ -115,7 +149,7 @@ if (typeof document !== 'undefined') {
     document.getElementById('summarize').addEventListener('click', async () => {
       const url = document.getElementById('url').value;
       const summaryEl = document.getElementById('summary');
-      summaryEl.textContent = '';
+      summaryEl.innerHTML = '';
       if (logEl) logEl.textContent = '';
       try {
         const record = await getKeyRecord();
@@ -130,7 +164,7 @@ if (typeof document !== 'undefined') {
         const { transcript, title } = await fetchTranscript(videoId);
         setStatus(`Summarizing "${title}"...`);
         const summary = await summarize(transcript, apiKey);
-        summaryEl.textContent = summary;
+        summaryEl.innerHTML = renderMarkdown(summary);
         setStatus('Done.');
       } catch (e) {
         setStatus('Error: ' + e.message);

--- a/prompt.md
+++ b/prompt.md
@@ -1,1 +1,3 @@
-You summarize YouTube transcripts into concise overviews followed by bullet-point conclusions.
+You summarize YouTube transcripts.
+Provide a three-sentence TLWR at the top, followed by a **Key Points** section as bullet points, and finish with a short conclusion.
+Return the result in valid Markdown.

--- a/styles.css
+++ b/styles.css
@@ -1,4 +1,36 @@
-body { font-family: Arial, sans-serif; margin: 2rem; max-width: 800px; }
-input, button { margin: 0.25rem 0; padding: 0.5rem; width: 100%; }
-#summary { white-space: pre-wrap; margin-top: 1rem; }
+body {
+  font-family: Arial, sans-serif;
+  margin: 2rem;
+  max-width: 800px;
+  background-color: #121212;
+  color: #e0e0e0;
+}
+
+input, button {
+  margin: 0.25rem 0;
+  padding: 0.5rem;
+  width: 100%;
+  background-color: #1e1e1e;
+  color: #e0e0e0;
+  border: 1px solid #333;
+}
+
+button {
+  cursor: pointer;
+}
+
+a {
+  color: #80cbc4;
+}
+
+#summary {
+  margin-top: 1rem;
+}
+
 .api { margin-top: 1rem; }
+
+pre {
+  background-color: #1e1e1e;
+  padding: 0.5rem;
+  overflow-x: auto;
+}


### PR DESCRIPTION
## Summary
- add dark theme styling and improve form elements
- enhance prompt for TLWR, key points, and conclusion in Markdown
- render markdown output on the page

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a6f916b4e883228cc36610a6d87350