### PR TITLE
Add history page with navigation bar

### DIFF
--- a/history.html
+++ b/history.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; connect-src 'self' https://api.groq.com https://youtubetotranscript.com; object-src 'none'; base-uri 'none'; require-trusted-types-for 'script'">
+  <title>History - YouSum</title>
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+  <nav>
+    <a href="index.html">📝 Sum</a>
+    <a href="history.html">📜 History</a>
+    <a href="settings.html">⚙️ Settings</a>
+  </nav>
+  <h1>History</h1>
+  <ul id="historyList"></ul>
+  <script src="errors.js"></script>
+  <script type="module" src="history.js"></script>
+</body>
+</html>

--- a/history.js
+++ b/history.js
@@ -1,0 +1,24 @@
+import { loadHistory } from './historyManager.js';
+
+document.addEventListener('DOMContentLoaded', () => {
+  const list = document.getElementById('historyList');
+  const items = loadHistory();
+  if (!items.length) {
+    const li = document.createElement('li');
+    li.textContent = 'No history yet.';
+    list.appendChild(li);
+    return;
+  }
+  for (const item of items) {
+    const li = document.createElement('li');
+    const titleLink = document.createElement('a');
+    titleLink.href = item.url;
+    titleLink.textContent = item.title;
+    titleLink.target = '_blank';
+    li.appendChild(titleLink);
+    const info = document.createElement('div');
+    info.textContent = `${item.channel} – ${item.summary}`;
+    li.appendChild(info);
+    list.appendChild(li);
+  }
+});

--- a/historyManager.js
+++ b/historyManager.js
@@ -1,0 +1,20 @@
+const HISTORY_KEY = 'yousum-history';
+
+export function loadHistory() {
+  try {
+    const raw = localStorage.getItem(HISTORY_KEY);
+    return raw ? JSON.parse(raw) : [];
+  } catch {
+    return [];
+  }
+}
+
+export function addHistory(entry) {
+  const items = loadHistory();
+  items.unshift(entry);
+  try {
+    localStorage.setItem(HISTORY_KEY, JSON.stringify(items));
+  } catch {
+    // ignore storage errors
+  }
+}

--- a/index.html
+++ b/index.html
@@ -8,6 +8,11 @@
     <link rel="stylesheet" href="styles.css">
 </head>
 <body>
+    <nav>
+      <a href="index.html">📝 Sum</a>
+      <a href="history.html">📜 History</a>
+      <a href="settings.html">⚙️ Settings</a>
+    </nav>
     <h1>YouTube Video Summarizer</h1>
     <p>Enter a YouTube URL to summarize its transcript. Configure your Groq API key and PIN on the <a href="settings.html">settings page</a>.</p>
     <input type="text" id="url" placeholder="YouTube URL">

--- a/settings.html
+++ b/settings.html
@@ -8,6 +8,11 @@
     <link rel="stylesheet" href="styles.css">
 </head>
 <body>
+    <nav>
+      <a href="index.html">📝 Sum</a>
+      <a href="history.html">📜 History</a>
+      <a href="settings.html">⚙️ Settings</a>
+    </nav>
     <h1>Settings</h1>
     <p>Use this page to configure the Groq API key and set up PIN protection.</p>
     <ol>
@@ -25,7 +30,6 @@
       <summary>Log</summary>
       <pre id="log"></pre>
     </details>
-    <p><a href="index.html">Back to summarizer</a></p>
 
     <script type="module" src="settings.js"></script>
 </body>

--- a/styles.css
+++ b/styles.css
@@ -34,3 +34,11 @@ pre {
   padding: 0.5rem;
   overflow-x: auto;
 }
+nav {
+  display: flex;
+  gap: 1rem;
+  margin-bottom: 1rem;
+}
+nav a {
+  text-decoration: none;
+}

--- a/tests/fetch-utils.test.js
+++ b/tests/fetch-utils.test.js
@@ -11,14 +11,15 @@ import { fetchTranscript, fetchWithRetry, summarize } from '../main.js';
 
 // fetchTranscript tests
 
-test('fetchTranscript parses transcript and title', async (t) => {
+test('fetchTranscript parses transcript, title, and channel', async (t) => {
   const html = '<title>Transcript of Some Title - YouTubeToTranscript.com</title>' +
-               '<span data-start="0">Hello</span><span data-start="1">World</span>';
+               '<span data-start="0">Hello</span><span data-start="1">World</span><a title="Visit YouTube Channel">Chan</a>';
   const origFetch = global.fetch;
   global.fetch = t.mock.fn(async () => ({ ok: true, text: async () => html }));
-  const { transcript, title } = await fetchTranscript('id');
+  const { transcript, title, channel } = await fetchTranscript('id');
   assert.equal(transcript, 'Hello World');
   assert.equal(title, 'Some Title');
+  assert.equal(channel, 'Chan');
   global.fetch = origFetch;
 });
 

--- a/tests/historyManager.test.js
+++ b/tests/historyManager.test.js
@@ -1,0 +1,27 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { addHistory, loadHistory } from '../historyManager.js';
+
+class FakeStorage {
+  constructor() { this.store = {}; }
+  getItem(k) { return Object.prototype.hasOwnProperty.call(this.store, k) ? this.store[k] : null; }
+  setItem(k, v) { this.store[k] = String(v); }
+  removeItem(k) { delete this.store[k]; }
+}
+
+const originalStorage = global.localStorage;
+
+test('addHistory stores and loadHistory retrieves entries', () => {
+  global.localStorage = new FakeStorage();
+  addHistory({ title: 't', channel: 'c', url: 'u', summary: 's', transcript: 'tr' });
+  const items = loadHistory();
+  assert.equal(items.length, 1);
+  assert.equal(items[0].title, 't');
+  global.localStorage = originalStorage;
+});
+
+test('loadHistory returns empty array when storage empty', () => {
+  global.localStorage = new FakeStorage();
+  assert.deepEqual(loadHistory(), []);
+  global.localStorage = originalStorage;
+});


### PR DESCRIPTION
## Summary
- add navigation bar across pages with links to Sum, History, and Settings
- store summaries and metadata in local storage and expose a history view
- extract YouTube channel name when fetching transcripts

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a737a047c483229588b51f8036ba69