### PR TITLE
Make history items collapsible and enforce coverage threshold

### DIFF
--- a/history.js
+++ b/history.js
@@ -1,4 +1,5 @@
 import { loadHistory } from './historyManager.js';
+import { renderMarkdown } from './render.js';
 
 document.addEventListener('DOMContentLoaded', () => {
   const list = document.getElementById('historyList');
@@ -11,14 +12,19 @@ document.addEventListener('DOMContentLoaded', () => {
   }
   for (const item of items) {
     const li = document.createElement('li');
+    const details = document.createElement('details');
+    const summary = document.createElement('summary');
     const titleLink = document.createElement('a');
     titleLink.href = item.url;
     titleLink.textContent = item.title;
     titleLink.target = '_blank';
-    li.appendChild(titleLink);
-    const info = document.createElement('div');
-    info.textContent = `${item.channel} – ${item.summary}`;
-    li.appendChild(info);
+    summary.appendChild(titleLink);
+    summary.append(` – ${item.channel}`);
+    details.appendChild(summary);
+    const content = document.createElement('div');
+    content.innerHTML = renderMarkdown(item.summary);
+    details.appendChild(content);
+    li.appendChild(details);
     list.appendChild(li);
   }
 });

--- a/main.js
+++ b/main.js
@@ -1,5 +1,8 @@
 import { getKeyRecord, decryptStoredKey } from './keyManager.js';
 import { addHistory } from './historyManager.js';
+import { renderMarkdown } from './render.js';
+
+export { renderMarkdown };
 
 export function parseVideoId(url) {
   try {
@@ -14,40 +17,6 @@ export function parseVideoId(url) {
     // ignore invalid URLs
   }
   return null;
-}
-
-export function renderMarkdown(md) {
-  const lines = md.split(/\r?\n/);
-  let html = '';
-  let inList = false;
-  for (let raw of lines) {
-    let line = raw
-      .replace(/&/g, '&amp;')
-      .replace(/</g, '&lt;')
-      .replace(/>/g, '&gt;')
-      .replace(/\*\*(.+?)\*\*/g, '<strong>$1</strong>')
-      .replace(/\*(.+?)\*/g, '<em>$1</em>');
-    if (/^###\s+/.test(line)) {
-      if (inList) { html += '</ul>'; inList = false; }
-      html += '<h3>' + line.replace(/^###\s+/, '') + '</h3>';
-    } else if (/^##\s+/.test(line)) {
-      if (inList) { html += '</ul>'; inList = false; }
-      html += '<h2>' + line.replace(/^##\s+/, '') + '</h2>';
-    } else if (/^#\s+/.test(line)) {
-      if (inList) { html += '</ul>'; inList = false; }
-      html += '<h1>' + line.replace(/^#\s+/, '') + '</h1>';
-    } else if (/^[-*]\s+/.test(line)) {
-      if (!inList) { html += '<ul>'; inList = true; }
-      html += '<li>' + line.replace(/^[-*]\s+/, '') + '</li>';
-    } else if (line.trim() === '') {
-      if (inList) { html += '</ul>'; inList = false; }
-    } else {
-      if (inList) { html += '</ul>'; inList = false; }
-      html += '<p>' + line + '</p>';
-    }
-  }
-  if (inList) html += '</ul>';
-  return html;
 }
 
 async function parseHtml(html) {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "test": "tests"
   },
   "scripts": {
-    "test": "node --test"
+    "test": "c8 --check-coverage --lines 85 --functions 85 --statements 85 node --test"
   },
   "keywords": [],
   "author": "",

--- a/render.js
+++ b/render.js
@@ -1,0 +1,33 @@
+export function renderMarkdown(md) {
+  const lines = md.split(/\r?\n/);
+  let html = '';
+  let inList = false;
+  for (let raw of lines) {
+    let line = raw
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/\*\*(.+?)\*\*/g, '<strong>$1</strong>')
+      .replace(/\*(.+?)\*/g, '<em>$1</em>');
+    if (/^###\s+/.test(line)) {
+      if (inList) { html += '</ul>'; inList = false; }
+      html += '<h3>' + line.replace(/^###\s+/, '') + '</h3>';
+    } else if (/^##\s+/.test(line)) {
+      if (inList) { html += '</ul>'; inList = false; }
+      html += '<h2>' + line.replace(/^##\s+/, '') + '</h2>';
+    } else if (/^#\s+/.test(line)) {
+      if (inList) { html += '</ul>'; inList = false; }
+      html += '<h1>' + line.replace(/^#\s+/, '') + '</h1>';
+    } else if (/^[-*]\s+/.test(line)) {
+      if (!inList) { html += '<ul>'; inList = true; }
+      html += '<li>' + line.replace(/^[-*]\s+/, '') + '</li>';
+    } else if (line.trim() === '') {
+      if (inList) { html += '</ul>'; inList = false; }
+    } else {
+      if (inList) { html += '</ul>'; inList = false; }
+      html += '<p>' + line + '</p>';
+    }
+  }
+  if (inList) html += '</ul>';
+  return html;
+}


### PR DESCRIPTION
## Summary
- Render history entries as collapsible `<details>` elements with channel name inline and markdown summary rendering.
- Extract `renderMarkdown` to a shared module and reuse in main and history pages.
- Fail tests when coverage drops below 85%.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a73e18e9188322954e55655fd88462