### PR TITLE
Ensure history page initializes after load

### DIFF
--- a/history.js
+++ b/history.js
@@ -11,7 +11,7 @@ if (typeof window !== 'undefined' && window.trustedTypes && !window.trustedTypes
 }
 
 if (typeof document !== 'undefined') {
-  document.addEventListener('DOMContentLoaded', () => {
+  const init = () => {
     const list = document.getElementById('historyList');
     const items = loadHistory();
     if (!items.length) {
@@ -37,6 +37,11 @@ if (typeof document !== 'undefined') {
       li.appendChild(details);
       list.appendChild(li);
     }
-  });
+  };
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', init);
+  } else {
+    init();
+  }
 }
 /* c8 ignore end */

--- a/tests/history.test.js
+++ b/tests/history.test.js
@@ -14,9 +14,28 @@ test('history.js sets trusted types policy', async () => {
       }
     }
   };
-  global.document = { addEventListener: () => {} };
-  await import('../history.js');
+  global.document = { addEventListener: () => {}, readyState: 'loading' };
+  await import('../history.js?policy');
   assert.ok(created, 'expected policy to be created');
   delete global.window;
   delete global.document;
+});
+
+test('history.js initializes if DOM is already loaded', async () => {
+  const { JSDOM } = await import('jsdom');
+  const dom = new JSDOM('<ul id="historyList"></ul>');
+  Object.defineProperty(dom.window.document, 'readyState', { value: 'complete', configurable: true });
+  global.window = dom.window;
+  global.document = dom.window.document;
+  global.localStorage = {
+    getItem() {
+      return JSON.stringify([{ url: 'u', title: 't', channel: 'c', summary: 's' }]);
+    },
+    setItem() {}
+  };
+  await import('../history.js?init');
+  assert.equal(dom.window.document.querySelectorAll('li').length, 1);
+  delete global.window;
+  delete global.document;
+  delete global.localStorage;
 });


### PR DESCRIPTION
## Summary
- Run history page initialization immediately if DOM is already loaded
- Add regression test covering DOM-ready initialization

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a787e5d63883228968a2bc0c78bfe9