### PR TITLE
feat: enlarge history controls and allow deletion

### DIFF
--- a/history.js
+++ b/history.js
@@ -1,4 +1,4 @@
-import { loadHistory } from './historyManager.js';
+import { loadHistory, deleteHistory } from './historyManager.js';
 import { renderMarkdown } from './render.js';
 
 /* c8 ignore start */
@@ -24,12 +24,44 @@ if (typeof document !== 'undefined') {
       const li = document.createElement('li');
       const details = document.createElement('details');
       const summary = document.createElement('summary');
+
+      const toggle = document.createElement('button');
+      toggle.textContent = '▶';
+      toggle.className = 'toggle';
+      toggle.addEventListener('click', e => {
+        e.preventDefault();
+        e.stopPropagation();
+        details.open = !details.open;
+        toggle.textContent = details.open ? '▼' : '▶';
+      });
+      summary.appendChild(toggle);
+
       const titleLink = document.createElement('a');
       titleLink.href = item.url;
       titleLink.textContent = item.title;
       titleLink.target = '_blank';
       summary.appendChild(titleLink);
       summary.append(` – ${item.channel}`);
+
+      const del = document.createElement('button');
+      del.textContent = '🗑️';
+      del.className = 'delete';
+      del.addEventListener('click', e => {
+        e.preventDefault();
+        e.stopPropagation();
+        if (confirm('Delete this entry?')) {
+          const idx = Array.from(list.children).indexOf(li);
+          deleteHistory(idx);
+          li.remove();
+          if (!list.children.length) {
+            const empty = document.createElement('li');
+            empty.textContent = 'No history yet.';
+            list.appendChild(empty);
+          }
+        }
+      });
+      summary.appendChild(del);
+
       details.appendChild(summary);
       const content = document.createElement('div');
       content.innerHTML = renderMarkdown(item.summary);

--- a/historyManager.js
+++ b/historyManager.js
@@ -18,3 +18,13 @@ export function addHistory(entry) {
     // ignore storage errors
   }
 }
+
+export function deleteHistory(index) {
+  const items = loadHistory();
+  items.splice(index, 1);
+  try {
+    localStorage.setItem(HISTORY_KEY, JSON.stringify(items));
+  } catch {
+    // ignore storage errors
+  }
+}

--- a/styles.css
+++ b/styles.css
@@ -42,3 +42,29 @@ nav {
 nav a {
   text-decoration: none;
 }
+
+details summary {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+summary button {
+  background-color: #1e1e1e;
+  border: 1px solid #333;
+  color: #e0e0e0;
+  padding: 0.25rem;
+  cursor: pointer;
+}
+
+summary button.toggle {
+  font-size: 1.25rem;
+  width: 2rem;
+  height: 2rem;
+}
+
+summary button.delete {
+  margin-left: auto;
+  width: 2rem;
+  height: 2rem;
+}

--- a/tests/history.test.js
+++ b/tests/history.test.js
@@ -39,3 +39,26 @@ test('history.js initializes if DOM is already loaded', async () => {
   delete global.document;
   delete global.localStorage;
 });
+
+test('history.js delete button removes entry', async () => {
+  const { JSDOM } = await import('jsdom');
+  const dom = new JSDOM('<ul id="historyList"></ul>');
+  Object.defineProperty(dom.window.document, 'readyState', { value: 'complete', configurable: true });
+  global.window = dom.window;
+  global.document = dom.window.document;
+  global.confirm = () => true;
+  global.localStorage = {
+    data: [{ url: 'u', title: 't', channel: 'c', summary: 's' }],
+    getItem() { return JSON.stringify(this.data); },
+    setItem(_k, v) { this.data = JSON.parse(v); }
+  };
+  await import('../history.js?delete');
+  dom.window.document.querySelector('button.delete').click();
+  const list = dom.window.document.querySelectorAll('li');
+  assert.equal(list.length, 1);
+  assert.equal(list[0].textContent, 'No history yet.');
+  delete global.window;
+  delete global.document;
+  delete global.localStorage;
+  delete global.confirm;
+});

--- a/tests/historyManager.test.js
+++ b/tests/historyManager.test.js
@@ -1,6 +1,6 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { addHistory, loadHistory } from '../historyManager.js';
+import { addHistory, loadHistory, deleteHistory } from '../historyManager.js';
 
 class FakeStorage {
   constructor() { this.store = {}; }
@@ -23,5 +23,16 @@ test('addHistory stores and loadHistory retrieves entries', () => {
 test('loadHistory returns empty array when storage empty', () => {
   global.localStorage = new FakeStorage();
   assert.deepEqual(loadHistory(), []);
+  global.localStorage = originalStorage;
+});
+
+test('deleteHistory removes entry by index', () => {
+  global.localStorage = new FakeStorage();
+  addHistory({ title: 't1', channel: 'c1', url: 'u1', summary: 's1' });
+  addHistory({ title: 't2', channel: 'c2', url: 'u2', summary: 's2' });
+  deleteHistory(0);
+  const items = loadHistory();
+  assert.equal(items.length, 1);
+  assert.equal(items[0].title, 't1');
   global.localStorage = originalStorage;
 });


### PR DESCRIPTION
## Summary
- add big toggle and delete buttons for history items
- style history controls for easier mobile interaction
- support deleting history entries in storage

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a78a57af3c8322af4c879d4f06653f