### PR TITLE
Remove bullets and extra left margin from history list

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -43,6 +43,12 @@ nav a {
   text-decoration: none;
 }
 
+#historyList {
+  list-style: none;
+  padding-left: 0;
+  margin-left: 0;
+}
+
 details summary {
   display: flex;
   align-items: center;


### PR DESCRIPTION
## Summary
- remove default bullets and indentation from history entries

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a87da4e8c883229476b0c1143c7650