### PR TITLE
Handle YouTube live URLs and strip tracking parameters

### DIFF
--- a/main.js
+++ b/main.js
@@ -4,6 +4,26 @@ import { renderMarkdown } from './render.js';
 
 export { renderMarkdown };
 
+export function stripTracking(url) {
+  try {
+    const u = new URL(url);
+    u.hash = '';
+    if (u.hostname.includes('youtube.com')) {
+      if (u.pathname.startsWith('/watch')) {
+        const v = u.searchParams.get('v');
+        u.search = v ? `?v=${v}` : '';
+      } else {
+        u.search = '';
+      }
+    } else if (u.hostname.includes('youtu.be')) {
+      u.search = '';
+    }
+    return u.toString();
+  } catch {
+    return url;
+  }
+}
+
 export function parseVideoId(url) {
   try {
     const u = new URL(url);
@@ -11,6 +31,9 @@ export function parseVideoId(url) {
       return u.pathname.slice(1);
     }
     if (u.hostname.includes('youtube.com')) {
+      if (u.pathname.startsWith('/live/')) {
+        return u.pathname.split('/')[2] || null;
+      }
       return u.searchParams.get('v');
     }
   } catch {
@@ -119,8 +142,8 @@ if (typeof document !== 'undefined') {
     if (!stored) {
       setStatus('No API key stored. Visit the settings page to configure one.');
     }
-    document.getElementById('summarize').addEventListener('click', async () => {
-      const url = document.getElementById('url').value;
+      document.getElementById('summarize').addEventListener('click', async () => {
+        const url = stripTracking(document.getElementById('url').value);
       const summaryEl = document.getElementById('summary');
       summaryEl.innerHTML = '';
       if (logEl) logEl.textContent = '';

--- a/tests/integration.test.js
+++ b/tests/integration.test.js
@@ -1,0 +1,10 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { parseVideoId, stripTracking } from '../main.js';
+
+test('stripTracking removes params and parseVideoId handles live URLs', () => {
+  const raw = 'https://www.youtube.com/live/_IYY70_L8Yc?si=GZk8dX-DchIUsgyi';
+  const cleaned = stripTracking(raw);
+  assert.equal(cleaned, 'https://www.youtube.com/live/_IYY70_L8Yc');
+  assert.equal(parseVideoId(cleaned), '_IYY70_L8Yc');
+});


### PR DESCRIPTION
## Summary
- Sanitize YouTube URLs to drop tracking data and preserve video identifiers
- Extend video ID parsing to support `youtube.com/live` links
- Add integration test ensuring live URLs are cleaned and parsed correctly

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a99ca9e9bc83228decb0ab3e021011