### PR TITLE
feat: hide sections until authenticated summarization

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ This project is a self-contained GitHub Pages site that summarizes the transcrip
 1. Open `settings.html` to configure the Groq API key. Enter the key and choose a PIN, then save it.
 2. (Optional) Use the **Decrypt stored key** button on the settings page to authenticate and verify the stored key by entering your PIN.
 3. Navigate to `index.html` (or the deployed GitHub Pages site).
-4. Enter the YouTube video URL and click **Summarize**. You will be prompted for your PIN to decrypt the stored API key before the summary is generated.
+4. Enter the YouTube video URL and click **Summarize**. You will be prompted for your PIN to decrypt the stored API key before the summary is generated. The log, summary, and **Ask Transcript** sections remain hidden until a summary is successfully created.
 5. To remove or change the key later, return to the settings page and use **Reset API Key**.
 6. Open `history.html` and click **Summarize recent news (latest 20)** to generate an aggregated overview across your most recent items; the app shows the period covered and the output cites which videos support each point.
 

--- a/index.html
+++ b/index.html
@@ -14,14 +14,14 @@
     <input type="text" id="url" placeholder="YouTube URL">
     <button id="summarize">Summarize</button>
     <div id="status"></div>
-    <details id="logBox">
+    <details id="logBox" class="hidden">
       <summary>Log</summary>
       <pre id="log"></pre>
     </details>
-    <h2>Summary</h2>
-    <div id="summary"></div>
+    <h2 id="summary-heading" class="hidden">Summary</h2>
+    <div id="summary" class="hidden"></div>
 
-    <h2>Ask Transcript</h2>
+    <h2 id="ask-heading" class="hidden">Ask Transcript</h2>
     <div id="askSection" class="hidden">
       <input type="text" id="question" placeholder="Ask a question">
       <button id="ask">Ask</button>

--- a/main.js
+++ b/main.js
@@ -95,12 +95,20 @@ if (typeof document !== 'undefined') {
   document.addEventListener('DOMContentLoaded', async () => {
     const status = document.getElementById('status');
     const logEl = document.getElementById('log');
-    const log = msg => { if (logEl) logEl.textContent += msg + '\n'; };
-    const setStatus = msg => { status.textContent = msg; log(msg); };
+    const logBox = document.getElementById('logBox');
+    const summaryHeader = document.getElementById('summary-heading');
+    const summaryEl = document.getElementById('summary');
+    const askHeader = document.getElementById('ask-heading');
     const askSection = document.getElementById('askSection');
     const questionEl = document.getElementById('question');
     const askBtn = document.getElementById('ask');
     const answerEl = document.getElementById('answer');
+    const log = msg => { if (logEl) logEl.textContent += msg + '\n'; };
+    const setStatus = msg => { status.textContent = msg; log(msg); };
+    if (logBox) logBox.classList.add('hidden');
+    if (summaryHeader) summaryHeader.classList.add('hidden');
+    if (summaryEl) summaryEl.classList.add('hidden');
+    if (askHeader) askHeader.classList.add('hidden');
     if (askSection) askSection.classList.add('hidden');
     let lastTranscript = '';
     let currentApiKey = '';
@@ -152,7 +160,6 @@ if (typeof document !== 'undefined') {
     }
       document.getElementById('summarize').addEventListener('click', async () => {
         const url = stripTracking(document.getElementById('url').value);
-      const summaryEl = document.getElementById('summary');
       summaryEl.innerHTML = '';
       if (logEl) logEl.textContent = '';
       try {
@@ -173,6 +180,9 @@ if (typeof document !== 'undefined') {
         setStatus(`Summarizing "${title}"...`);
         const summary = await summarize(transcript, apiKey);
         summaryEl.innerHTML = renderMarkdown(summary);
+        if (logBox) logBox.classList.remove('hidden');
+        if (summaryHeader) summaryHeader.classList.remove('hidden');
+        if (summaryEl) summaryEl.classList.remove('hidden');
         addHistory({ title, channel, url, summary, transcript, createdAt: new Date().toISOString() });
         lastTranscript = transcript;
         currentApiKey = apiKey;
@@ -182,6 +192,7 @@ if (typeof document !== 'undefined') {
           answerEl.innerHTML = '';
           questionEl.value = '';
         }
+        if (askHeader) askHeader.classList.remove('hidden');
         setStatus('Done.');
       } catch (e) {
         setStatus('Error: ' + e.message);

--- a/main.js
+++ b/main.js
@@ -105,11 +105,21 @@ if (typeof document !== 'undefined') {
     const answerEl = document.getElementById('answer');
     const log = msg => { if (logEl) logEl.textContent += msg + '\n'; };
     const setStatus = msg => { status.textContent = msg; log(msg); };
-    if (logBox) logBox.classList.add('hidden');
-    if (summaryHeader) summaryHeader.classList.add('hidden');
-    if (summaryEl) summaryEl.classList.add('hidden');
-    if (askHeader) askHeader.classList.add('hidden');
-    if (askSection) askSection.classList.add('hidden');
+    const hideInitialSections = () => {
+      [logBox, summaryHeader, summaryEl, askHeader, askSection].forEach(el => {
+        if (el) el.classList.add('hidden');
+      });
+    };
+    const showSectionAfterSummary = () => {
+      [logBox, summaryHeader, summaryEl, askHeader, askSection].forEach(el => {
+        if (el) el.classList.remove('hidden');
+      });
+      if (askSection) {
+        answerEl.innerHTML = '';
+        questionEl.value = '';
+      }
+    };
+    hideInitialSections();
     let lastTranscript = '';
     let currentApiKey = '';
     let keyClearTimer;
@@ -180,19 +190,11 @@ if (typeof document !== 'undefined') {
         setStatus(`Summarizing "${title}"...`);
         const summary = await summarize(transcript, apiKey);
         summaryEl.innerHTML = renderMarkdown(summary);
-        if (logBox) logBox.classList.remove('hidden');
-        if (summaryHeader) summaryHeader.classList.remove('hidden');
-        if (summaryEl) summaryEl.classList.remove('hidden');
+        showSectionAfterSummary();
         addHistory({ title, channel, url, summary, transcript, createdAt: new Date().toISOString() });
         lastTranscript = transcript;
         currentApiKey = apiKey;
         scheduleKeyClear();
-        if (askSection) {
-          askSection.classList.remove('hidden');
-          answerEl.innerHTML = '';
-          questionEl.value = '';
-        }
-        if (askHeader) askHeader.classList.remove('hidden');
         setStatus('Done.');
       } catch (e) {
         setStatus('Error: ' + e.message);

--- a/tests/index-visibility.test.js
+++ b/tests/index-visibility.test.js
@@ -1,0 +1,14 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import { readFile } from 'node:fs/promises';
+import { JSDOM } from 'jsdom';
+
+test('initial sections are hidden', async () => {
+  const html = await readFile(new URL('../index.html', import.meta.url), 'utf8');
+  const { document } = new JSDOM(html).window;
+  assert.ok(document.getElementById('logBox').classList.contains('hidden'));
+  assert.ok(document.getElementById('summary-heading').classList.contains('hidden'));
+  assert.ok(document.getElementById('summary').classList.contains('hidden'));
+  assert.ok(document.getElementById('ask-heading').classList.contains('hidden'));
+  assert.ok(document.getElementById('askSection').classList.contains('hidden'));
+});


### PR DESCRIPTION
## Summary
- hide log, summary, and Q&A sections until a summary is generated with a valid PIN
- ensure sections become visible after a successful summary
- document visibility behavior and test initial hidden state

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b0cba284888322895420d3c0e80844